### PR TITLE
adds pointerEvents method to Shape Class

### DIFF
--- a/src/Shape/Shape.js
+++ b/src/Shape/Shape.js
@@ -57,6 +57,7 @@ export default class Shape extends BaseClass {
     };
     this._name = "Shape";
     this._opacity = constant(1);
+    this._pointerEvents = constant("visiblePainted");
     this._rx = constant(0);
     this._ry = constant(0);
     this._scale = constant(1);
@@ -492,7 +493,7 @@ export default class Shape extends BaseClass {
       .transition(this._transition)
       .attr("opacity", this._nestWrapper(this._opacity))
       .transition()
-      .attr("pointer-events", "all");
+      .attr("pointer-events", this._pointerEvents);
 
     // Makes the exit state of the group selection accessible.
     const exit = this._exit = update.exit();
@@ -741,6 +742,16 @@ function(d, i, shape) {
   */
   opacity(_) {
     return arguments.length ? (this._opacity = typeof _ === "function" ? _ : constant(_), this) : this._opacity;
+  }
+
+  /**
+       @memberof Shape
+       @desc If *value* is specified, sets the pointerEvents accessor to the specified function or string and returns the current class instance.
+       @param {String} [*value*]
+       @chainable
+   */
+  pointerEvents(_) {
+    return arguments.length ? (this._pointerEvents = typeof _ === "function" ? _ : constant(_), this) : this._pointerEvents;
   }
 
   /**

--- a/test/Shape/Rect.js
+++ b/test/Shape/Rect.js
@@ -10,6 +10,7 @@ test("Shape/Rect", function *(assert) {
       .duration(100)
       .height(200)
       .label(d => d.id)
+      .pointerEvents("fill")
       .width(100)
       .x(100)
       .y(50)
@@ -19,6 +20,7 @@ test("Shape/Rect", function *(assert) {
 
   assert.equal(document.getElementsByTagName("svg").length, 1, "automatically added <svg> element to page");
   assert.equal(document.getElementsByClassName("d3plus-Rect").length, 1, "created <g> container element");
+  assert.equal(document.getElementsByClassName("d3plus-Rect")[0].getAttribute("pointer-events"), "fill", "set pointerEvents attribute of shape");
   assert.equal(document.getElementsByTagName("rect").length, 1, "created <rect> element");
   assert.equal(document.getElementsByTagName("text").length, 1, "created <text> element");
   const tspans = document.getElementsByTagName("tspan");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
(closes #68 )
### Description
<!--- Describe your changes in detail -->
Adds a pointerEvents method to the Shape Class which allows allow users to define custom values for the `pointer-events` property of a shape. This also changes the default value for `pointerEvents` from `all` to [visiblePainted](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/pointer-events), which fixes the hit area of lines.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have documented all new methods.
- [x] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

