### PR TITLE
increases default hit area for Line

### DIFF
--- a/src/Shape/Line.js
+++ b/src/Shape/Line.js
@@ -4,7 +4,7 @@ import {interpolatePath} from "d3-interpolate-path";
 import {select} from "d3-selection";
 import * as paths from "d3-shape";
 
-import {constant, merge} from "d3plus-common";
+import {attrize, constant, merge} from "d3plus-common";
 
 import Shape from "./Shape";
 
@@ -81,7 +81,7 @@ export default class Line extends Shape {
 
     const that = this;
 
-    const drawLine = () => {
+    const drawLine = (styles = {}) => {
       this._path
         .curve(paths[`curve${this._curve.charAt(0).toUpperCase()}${this._curve.slice(1)}`])
         .defined(this._defined)
@@ -91,32 +91,24 @@ export default class Line extends Shape {
       this._enter.append("path")
         .attr("transform", d => `translate(${-d.xR[0] - d.width / 2}, ${-d.yR[0] - d.height / 2})`)
         .attr("d", d => this._path(d.values))
-        .call(this._applyStyle.bind(this));
+        .call(this._applyStyle.bind(this))
+        .call(attrize, styles);
 
       this._update.select("path").transition(this._transition)
         .attr("transform", d => `translate(${-d.xR[0] - d.width / 2}, ${-d.yR[0] - d.height / 2})`)
         .attrTween("d", function(d) {
           return interpolatePath(select(this).attr("d"), that._path(d.values));
         })
-        .call(this._applyStyle.bind(this));
+        .call(this._applyStyle.bind(this))
+        .call(attrize, styles);
     };
 
     drawLine();
 
     const hitAreaWidth = 10;
-    const currentStrokeWidth = this._strokeWidth();
 
-    if (currentStrokeWidth < hitAreaWidth) {
-      const currentStroke = this._stroke();
-      const hitAreaStroke = "transparent";
-
-      this._strokeWidth = constant(hitAreaWidth);
-      this._stroke = constant(hitAreaStroke);
-
-      drawLine();
-
-      this._strokeWidth = constant(currentStrokeWidth);
-      this._stroke = constant(currentStroke);
+    if (this._strokeWidth() < hitAreaWidth) {
+      drawLine({"stroke-width": hitAreaWidth, "stroke": "transparent", "fill": "transparent"});
     }
 
     return this;

--- a/src/Shape/Line.js
+++ b/src/Shape/Line.js
@@ -27,7 +27,11 @@ export default class Line extends Shape {
     this._curve = "linear";
     this._defined = d => d;
     this._fill = constant("none");
-    this._hitArea = constant({"stroke-width": 10});
+    this._hitArea = constant({
+      "d": d => this._path(d.values),
+      "stroke-width": 10,
+      "transform": null
+    });
     this._name = "Line";
     this._path = paths.line();
     this._stroke = constant("black");

--- a/src/Shape/Line.js
+++ b/src/Shape/Line.js
@@ -81,23 +81,43 @@ export default class Line extends Shape {
 
     const that = this;
 
-    this._path
-      .curve(paths[`curve${this._curve.charAt(0).toUpperCase()}${this._curve.slice(1)}`])
-      .defined(this._defined)
-      .x(this._x)
-      .y(this._y);
+    const drawLine = () => {
+      this._path
+        .curve(paths[`curve${this._curve.charAt(0).toUpperCase()}${this._curve.slice(1)}`])
+        .defined(this._defined)
+        .x(this._x)
+        .y(this._y);
 
-    this._enter.append("path")
-      .attr("transform", d => `translate(${-d.xR[0] - d.width / 2}, ${-d.yR[0] - d.height / 2})`)
-      .attr("d", d => this._path(d.values))
-      .call(this._applyStyle.bind(this));
+      this._enter.append("path")
+        .attr("transform", d => `translate(${-d.xR[0] - d.width / 2}, ${-d.yR[0] - d.height / 2})`)
+        .attr("d", d => this._path(d.values))
+        .call(this._applyStyle.bind(this));
 
-    this._update.select("path").transition(this._transition)
-      .attr("transform", d => `translate(${-d.xR[0] - d.width / 2}, ${-d.yR[0] - d.height / 2})`)
-      .attrTween("d", function(d) {
-        return interpolatePath(select(this).attr("d"), that._path(d.values));
-      })
-      .call(this._applyStyle.bind(this));
+      this._update.select("path").transition(this._transition)
+        .attr("transform", d => `translate(${-d.xR[0] - d.width / 2}, ${-d.yR[0] - d.height / 2})`)
+        .attrTween("d", function(d) {
+          return interpolatePath(select(this).attr("d"), that._path(d.values));
+        })
+        .call(this._applyStyle.bind(this));
+    };
+
+    drawLine();
+
+    const hitAreaWidth = 10;
+    const currentStrokeWidth = this._strokeWidth();
+
+    if (currentStrokeWidth < hitAreaWidth) {
+      const currentStroke = this._stroke();
+      const hitAreaStroke = "transparent";
+
+      this._strokeWidth = constant(hitAreaWidth);
+      this._stroke = constant(hitAreaStroke);
+
+      drawLine();
+
+      this._strokeWidth = constant(currentStrokeWidth);
+      this._stroke = constant(currentStroke);
+    }
 
     return this;
 

--- a/src/Shape/Line.js
+++ b/src/Shape/Line.js
@@ -4,7 +4,7 @@ import {interpolatePath} from "d3-interpolate-path";
 import {select} from "d3-selection";
 import * as paths from "d3-shape";
 
-import {attrize, constant, merge} from "d3plus-common";
+import {constant, merge} from "d3plus-common";
 
 import Shape from "./Shape";
 
@@ -27,6 +27,7 @@ export default class Line extends Shape {
     this._curve = "linear";
     this._defined = d => d;
     this._fill = constant("none");
+    this._hitArea = constant({"stroke-width": 10});
     this._name = "Line";
     this._path = paths.line();
     this._stroke = constant("black");
@@ -81,35 +82,23 @@ export default class Line extends Shape {
 
     const that = this;
 
-    const drawLine = (styles = {}) => {
-      this._path
-        .curve(paths[`curve${this._curve.charAt(0).toUpperCase()}${this._curve.slice(1)}`])
-        .defined(this._defined)
-        .x(this._x)
-        .y(this._y);
+    this._path
+      .curve(paths[`curve${this._curve.charAt(0).toUpperCase()}${this._curve.slice(1)}`])
+      .defined(this._defined)
+      .x(this._x)
+      .y(this._y);
 
-      this._enter.append("path")
-        .attr("transform", d => `translate(${-d.xR[0] - d.width / 2}, ${-d.yR[0] - d.height / 2})`)
-        .attr("d", d => this._path(d.values))
-        .call(this._applyStyle.bind(this))
-        .call(attrize, styles);
+    this._enter.append("path")
+      .attr("transform", d => `translate(${-d.xR[0] - d.width / 2}, ${-d.yR[0] - d.height / 2})`)
+      .attr("d", d => this._path(d.values))
+      .call(this._applyStyle.bind(this));
 
-      this._update.select("path").transition(this._transition)
-        .attr("transform", d => `translate(${-d.xR[0] - d.width / 2}, ${-d.yR[0] - d.height / 2})`)
-        .attrTween("d", function(d) {
-          return interpolatePath(select(this).attr("d"), that._path(d.values));
-        })
-        .call(this._applyStyle.bind(this))
-        .call(attrize, styles);
-    };
-
-    drawLine();
-
-    const hitAreaWidth = 10;
-
-    if (this._strokeWidth() < hitAreaWidth) {
-      drawLine({"stroke-width": hitAreaWidth, "stroke": "transparent", "fill": "transparent"});
-    }
+    this._update.select("path").transition(this._transition)
+      .attr("transform", d => `translate(${-d.xR[0] - d.width / 2}, ${-d.yR[0] - d.height / 2})`)
+      .attrTween("d", function(d) {
+        return interpolatePath(select(this).attr("d"), that._path(d.values));
+      })
+      .call(this._applyStyle.bind(this));
 
     return this;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
Increases the default hit area for Line to be a width of 10px. (closes #33 )

### Description
<!--- Describe your changes in detail -->
This changes the way the render method for Line works so that now it draws the line normally, and then if the strokeWidth is less than 10px, draws another transparent line with a strokeWidth of 10px.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

