### PR TITLE
adds rotation to label rendering

### DIFF
--- a/src/Shape/Shape.js
+++ b/src/Shape/Shape.js
@@ -414,7 +414,7 @@ export default class Shape extends BaseClass {
                 height: b.height,
                 l,
                 id: `${this._id(d, i)}_${l}`,
-                r: bounds.angle !== undefined ? bounds.angle : 0,
+                r: d.labelConfig && d.labelConfig.rotate ? d.labelConfig.rotate : bounds.angle !== undefined ? bounds.angle : 0,
                 text: labels[l],
                 width: b.width,
                 x: x + b.x,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

### Description
<!--- Describe your changes in detail -->
This change is required in order for the  [label rotation in d3plus-axis](https://github.com/d3plus/d3plus-axis/pull/44) to work.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

