### PR TITLE
adds hoverStyle method to Shape

### DIFF
--- a/src/Shape/Shape.js
+++ b/src/Shape/Shape.js
@@ -49,10 +49,10 @@ export default class Shape extends BaseClass {
 
     this._hoverOpacity = 0.5;
     this._hoverStyle = {
-      "stroke": "#444444",
+      "stroke": "#888888",
       "stroke-width": (d, i) => {
         const s = this._strokeWidth(d, i) || 1;
-        return s * 3;
+        return s * 2;
       }
     };
     this._id = (d, i) => d.id !== void 0 ? d.id : i;

--- a/src/Shape/Shape.js
+++ b/src/Shape/Shape.js
@@ -122,11 +122,12 @@ export default class Shape extends BaseClass {
 
   /**
       @memberof Shape
-      @desc Provides the default styling to the active shape elements.
+      @desc Provides the updated styling to the given shape elements.
       @param {HTMLElement} *elem*
+      @param {Object} *style*
       @private
   */
-  _applyActive(elem) {
+  _updateStyle(elem, style) {
 
     const that = this;
 
@@ -145,50 +146,14 @@ export default class Shape extends BaseClass {
           : this(d, i);
     }
 
-    const activeStyle = {};
-    for (const key in this._activeStyle) {
-      if ({}.hasOwnProperty.call(this._activeStyle, key)) {
-        activeStyle[key] = styleLogic.bind(this._activeStyle[key]);
+    const styleObject = {};
+    for (const key in style) {
+      if ({}.hasOwnProperty.call(style, key)) {
+        styleObject[key] = styleLogic.bind(style[key]);
       }
     }
 
-    elem.transition().duration(0).call(attrize, activeStyle);
-
-  }
-
-  /**
-      @memberof Shape
-      @desc Provides the default styling to the hovered shape elements.
-      @param {HTMLElement} *elem*
-      @private
-   */
-  _applyHover(elem) {
-
-    const that = this;
-
-    if (elem.size() && elem.node().tagName === "g") elem = elem.selectAll("*");
-
-    /**
-     @desc Determines whether a shape is a nested collection of data points, and uses the appropriate data and index for the given function context.
-     @param {Object} *d* data point
-     @param {Number} *i* index
-     @private
-     */
-    function styleLogic(d, i) {
-      return typeof this !== "function" ? this
-        : d.nested && d.key && d.values
-          ? this(d.values[0], that._data.indexOf(d.values[0]))
-          : this(d, i);
-    }
-
-    const hoverStyle = {};
-    for (const key in this._hoverStyle) {
-      if ({}.hasOwnProperty.call(this._hoverStyle, key)) {
-        hoverStyle[key] = styleLogic.bind(this._hoverStyle[key]);
-      }
-    }
-
-    elem.transition().duration(0).call(attrize, hoverStyle);
+    elem.transition().duration(0).call(attrize, styleObject);
 
   }
 
@@ -288,7 +253,7 @@ export default class Shape extends BaseClass {
           group.appendChild(this);
           if (this.className.baseVal.includes("d3plus-Shape")) {
             if (parent === group) select(this).call(that._applyStyle.bind(that));
-            else select(this).call(that._applyActive.bind(that));
+            else select(this).call(that._updateStyle.bind(that, select(this), that._activeStyle));
           }
         }
 
@@ -332,7 +297,7 @@ export default class Shape extends BaseClass {
         if (group !== this.parentNode) group.appendChild(this);
         if (this.className.baseVal.includes("d3plus-Shape")) {
           if (parent === group) select(this).call(that._applyStyle.bind(that));
-          else select(this).call(that._applyHover.bind(that));
+          else select(this).call(that._updateStyle.bind(that, select(this), that._hoverStyle));
         }
 
       });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
(closes #73 )

### Description
<!--- Describe your changes in detail -->
Adds the `.hoverStyle( )` method to shape and sets the default hover styles to: 
```
"stroke": "#444444",
"stroke-width": (d, i) => {
    const s = this._strokeWidth(d, i) || 1;
    return s * 3;
}
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

