### PR TITLE
fixes rotateAnchor bug

### DIFF
--- a/src/Shape/Shape.js
+++ b/src/Shape/Shape.js
@@ -426,7 +426,7 @@ export default class Shape extends BaseClass {
               const rotate = this._rotate(d, i);
               let r = d.labelConfig && d.labelConfig.rotate ? d.labelConfig.rotate : bounds.angle !== undefined ? bounds.angle : 0;
               r += rotate;
-              const rotateAnchor = rotate !== 0 && bounds && [bounds.x * -1 || 0, bounds.y * -1 || 0];
+              const rotateAnchor = rotate !== 0 ? [b.x * -1 || 0, b.y * -1 || 0] : [b.width / 2, b.height / 2];
 
               labelData.push({
                 __d3plus__: true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
(closes #76 )

### Description
<!--- Describe your changes in detail -->
This bug was caused by a `false` value (which is invalid) being passed to `rotateAnchor` [on line 429](https://github.com/d3plus/d3plus-shape/blob/master/src/Shape/Shape.js#L429). This PR changes the default value from `false` to `[b.width / 2, b.height / 2]`, which is the default value in `TextBox`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

