### PR TITLE
Added support for aria-label #78 and role #79 attributes.

### DIFF
--- a/src/Shape/Shape.js
+++ b/src/Shape/Shape.js
@@ -44,7 +44,7 @@ export default class Shape extends BaseClass {
         return s * 3;
       }
     };
-    this._ariaLabel = "";
+    this._ariaLabel = constant("");
     this._backgroundImage = constant(false);
     this._backgroundImageClass = new Image();
     this._data = [];
@@ -75,7 +75,7 @@ export default class Shape extends BaseClass {
     this._name = "Shape";
     this._opacity = constant(1);
     this._pointerEvents = constant("visiblePainted");
-    this._role = "presentation";
+    this._role = constant("presentation");
     this._rotate = constant(0);
     this._rx = constant(0);
     this._ry = constant(0);

--- a/src/Shape/Shape.js
+++ b/src/Shape/Shape.js
@@ -44,6 +44,7 @@ export default class Shape extends BaseClass {
         return s * 3;
       }
     };
+    this._ariaLabel = "";
     this._backgroundImage = constant(false);
     this._backgroundImageClass = new Image();
     this._data = [];
@@ -74,6 +75,7 @@ export default class Shape extends BaseClass {
     this._name = "Shape";
     this._opacity = constant(1);
     this._pointerEvents = constant("visiblePainted");
+    this._role = "presentation";
     this._rotate = constant(0);
     this._rx = constant(0);
     this._ry = constant(0);
@@ -514,6 +516,8 @@ export default class Shape extends BaseClass {
     const enter = this._enter = update.enter().append(this._tagName)
       .attr("class", (d, i) => `d3plus-Shape d3plus-${this._name} d3plus-id-${strip(this._nestWrapper(this._id)(d, i))}`)
       .call(this._applyTransform.bind(this))
+      .attr("aria-label", this._ariaLabel)
+      .attr("role", this._role)
       .attr("opacity", this._nestWrapper(this._opacity));
 
     const enterUpdate = enter.merge(update);
@@ -618,6 +622,18 @@ export default class Shape extends BaseClass {
   */
   activeStyle(_) {
     return arguments.length ? (this._activeStyle = assign({}, this._activeStyle, _), this) : this._activeStyle;
+  }
+
+  /**
+      @memberof Shape
+      @desc If *value* is specified, sets the aria-label attribute to the specified function or string and returns the current class instance.
+      @param {Function|String} *value*
+      @chainable
+  */
+  ariaLabel(_) {
+    return _ !== undefined 
+      ? (this._ariaLabel = typeof _ === "function" ? _ : constant(_), this) 
+      : this._ariaLabel;
   }
 
   /**
@@ -798,13 +814,25 @@ function(d, i, shape) {
   }
 
   /**
-       @memberof Shape
-       @desc If *value* is specified, sets the pointerEvents accessor to the specified function or string and returns the current class instance.
-       @param {String} [*value*]
-       @chainable
+      @memberof Shape
+      @desc If *value* is specified, sets the pointerEvents accessor to the specified function or string and returns the current class instance.
+      @param {String} [*value*]
+      @chainable
    */
   pointerEvents(_) {
     return arguments.length ? (this._pointerEvents = typeof _ === "function" ? _ : constant(_), this) : this._pointerEvents;
+  }
+
+  /**
+      @memberof Shape
+      @desc If *value* is specified, sets the role attribute to the specified function or string and returns the current class instance.
+      @param {Function|String} *value*
+      @chainable
+  */
+  role(_) {
+    return _ !== undefined 
+      ? (this._role = typeof _ === "function" ? _ : constant(_), this) 
+      : this._role;
   }
 
   /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

### Description
<!--- Describe your changes in detail -->
aria-label #78:
- assigned default value in the constructor
- assigned aria-label attribute to this._enter variable
- created a user-accessible method, ariaLabel, to change the value
closes #78

role #79 :
- assigned default value in the constructor
- assigned aria-label attribute to this._enter variable
- created a user-accessible method, role, to change the value
closes #79

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [x] I have written examples for all new methods/functionality.

