### PR TITLE
wraps labelConfig in configPrep

### DIFF
--- a/src/Shape/Shape.js
+++ b/src/Shape/Shape.js
@@ -8,7 +8,7 @@ import {color} from "d3-color";
 import {mouse, select, selectAll} from "d3-selection";
 import {transition} from "d3-transition";
 
-import {accessor, assign, attrize, BaseClass, constant, elem} from "d3plus-common";
+import {accessor, assign, attrize, BaseClass, configPrep, constant, elem} from "d3plus-common";
 import {colorContrast} from "d3plus-color";
 import * as paths from "d3-shape";
 import {strip, TextBox} from "d3plus-text";
@@ -467,7 +467,7 @@ export default class Shape extends BaseClass {
       .rotate(d => d.__d3plus__ ? d.r : d.data.r)
       .rotateAnchor(d => d.__d3plus__ ? d.rotateAnchor : d.data.rotateAnchor)
       .select(elem(`g.d3plus-${this._name}-text`, {parent: this._group, update: {opacity: this._active ? this._activeOpacity : 1}}).node())
-      .config(this._labelConfig)
+      .config(configPrep.bind(this)(this._labelConfig))
       .render();
 
   }


### PR DESCRIPTION
(closes #84)
### Description
<!--- Describe your changes in detail -->
This bug was caused because `this._labelClass()` was defined without `configPrep` in `labelConfig()`.

For to solve it, I added configPrep in `.labelConfig()`
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

